### PR TITLE
fix: apply dark-mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -143,8 +143,10 @@ const app = {
       e.preventDefault();
       document.querySelector("body").classList.toggle('dark-mode')
       app.GUI.dark_mode.classList.toggle('active')
-      if (e instanceof PointerEvent)
-        localStorage.setItem('dark_mode', parseInt(localStorage.getItem('dark_mode')) ? 0 : 1)
+      if (e instanceof Event) {
+        let newValue = parseInt(localStorage.getItem('dark_mode')) ? 0 : 1
+        localStorage.setItem('dark_mode', newValue)
+      }
     },
 
     /**


### PR DESCRIPTION
By a little mistake I used **PointerEvent** as click identifier, but `e` is an instance of **Event**, now it works as desired. 🍪 